### PR TITLE
Use async calls, and use a higher level socket connection

### DIFF
--- a/custom_components/dobiss/dobiss.py
+++ b/custom_components/dobiss/dobiss.py
@@ -145,7 +145,7 @@ class DobissSystem:
 
     async def reconnect(self, data):
         _LOGGER.info(f"Dobiss for the reconnect")
-        # self.disconnect()
+        self.disconnect()
         await self.connect()
         if data:
             await self.sendData(data)

--- a/custom_components/dobiss/light.py
+++ b/custom_components/dobiss/light.py
@@ -86,10 +86,16 @@ class HomeAssistantDobissLight(CoordinatorEntity, LightEntity):
         """
         _LOGGER.debug("async_turn_on")
         pct = int(kwargs.get(ATTR_BRIGHTNESS, 255) * 100 / 255)
-        self.dobiss.setOn(self._light['moduleAddress'], self._light['index'], pct)
-
-        # Poll states
+        await self.dobiss.setOn(self._light['moduleAddress'], self._light['index'], pct)
         await self.coordinator.async_request_refresh()
+
+    @property
+    def supported_color_modes(self):
+        return [ColorMode.ONOFF]
+
+    @property
+    def color_mode(self):
+        return ColorMode.ONOFF
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""

--- a/custom_components/dobiss/light.py
+++ b/custom_components/dobiss/light.py
@@ -1,18 +1,19 @@
 """Dobiss Light Control"""
 import logging
-import voluptuous as vol
+# import voluptuous as vol
 from .dobiss import DobissSystem
 from .const import DOMAIN
+# import asyncio
 
-from homeassistant.components.light import SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS, LightEntity, LightEntityFeature
+from homeassistant.components.light import SUPPORT_BRIGHTNESS, ATTR_BRIGHTNESS, LightEntity, LightEntityFeature, \
+    ColorMode
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
 
 _LOGGER = logging.getLogger(__name__)
 
-        
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Setup the Dobiss Light platform."""
+    """Set up the Dobiss Light platform."""
     coordinator = hass.data[DOMAIN]["coordinator"]
 
     lights = coordinator.dobiss.lights
@@ -23,7 +24,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(
         HomeAssistantDobissLight(coordinator, light) for light in lights
     )
-    
+
     _LOGGER.info("Dobiss lights added.")
 
 
@@ -44,17 +45,18 @@ class HomeAssistantDobissLight(CoordinatorEntity, LightEntity):
         if self.dobiss.modules[self._light['moduleAddress']]['type'] == DobissSystem.ModuleType.Relais:
             return LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
         else:
-            return LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
+            # TODO: what else then?
+            return LightEntityFeature.FLASH | LightEntityFeature.TRANSITION | SUPPORT_BRIGHTNESS
 
     @property
     def unique_id(self):
-        return "{}.{}".format(self._light['moduleAddress'], self._light['index'])
+        return f"{self._light['moduleAddress']}.{self._light['index']}"
 
     @property
     def device_extra_attributes(self):
         """Return device specific state attributes."""
         return self._light
-    
+
     @property
     def name(self):
         """Return the display name of this light."""
@@ -74,7 +76,7 @@ class HomeAssistantDobissLight(CoordinatorEntity, LightEntity):
     def is_on(self):
         """Return true if light is on."""
         val = self.coordinator.data[self._light['moduleAddress']][self._light['index']]
-        return (val > 0)
+        return val > 0
 
     async def async_turn_on(self, **kwargs):
         """Instruct the light to turn on.
@@ -82,6 +84,7 @@ class HomeAssistantDobissLight(CoordinatorEntity, LightEntity):
         You can skip the brightness part if your light does not support
         brightness control.
         """
+        _LOGGER.debug("async_turn_on")
         pct = int(kwargs.get(ATTR_BRIGHTNESS, 255) * 100 / 255)
         self.dobiss.setOn(self._light['moduleAddress'], self._light['index'], pct)
 
@@ -90,7 +93,6 @@ class HomeAssistantDobissLight(CoordinatorEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        self.dobiss.setOff(self._light['moduleAddress'], self._light['index'])
-
-        # Poll states
+        _LOGGER.debug("async_turn_off")
+        await self.dobiss.setOff(self._light['moduleAddress'], self._light['index'])
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Previous code, because it was not async, and because, I guess the HA code could be improved, if the add-on is stuck in some infinite loop, trying to re-establish connection (very aggressively), it would bring the whole HA down.

A couple of things are happening here:

- port the light code (at least), so it's async in nature, isolating it from the HA main thread
- if the connection does go down, have an incremental backoff
- moved connect to create_connection, as there's no need to go low level for this (probably some more clean up can happen due to this change)
- added some more properties that will become mandatory for HA (color modes)


sorry for not breaking up these individual changes into separate PRs, but feel free to cherry pick